### PR TITLE
feat: add API service and integrate transfer

### DIFF
--- a/lib/screens/transfer_money.dart
+++ b/lib/screens/transfer_money.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../main.dart';
+import '../services/api_service.dart';
 import 'choose_value.dart';
 
 class TransferMoneyScreen extends StatelessWidget {
@@ -35,6 +36,8 @@ class TransferMoneyScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final apiService = ApiService();
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('Transfer Money'),
@@ -44,8 +47,22 @@ class TransferMoneyScreen extends StatelessWidget {
       body: Padding(
         padding: const EdgeInsets.all(16.0),
         child: Column(children: [
-          _tile(context, 'PayPal', 'Transfer Money to your PayPal Account', Icons.account_balance_wallet_outlined,
-              () => Navigator.pushNamed(context, ChooseValueScreen.route)),
+          _tile(
+            context,
+            'PayPal',
+            'Transfer Money to your PayPal Account',
+            Icons.account_balance_wallet_outlined,
+            () async {
+              try {
+                await apiService.transferMoney(provider: 'paypal', amount: 10);
+                // Navigate after successful transfer or to continue the flow.
+                Navigator.pushNamed(context, ChooseValueScreen.route);
+              } catch (e) {
+                ScaffoldMessenger.of(context)
+                    .showSnackBar(SnackBar(content: Text('Transfer failed: $e')));
+              }
+            },
+          ),
           const SizedBox(height: 12),
           _tile(context, 'Venmo', 'Transfer Money to your Venmo account', Icons.payments_outlined, () {}),
           const SizedBox(height: 12),

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -1,0 +1,68 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+/// Service responsible for communicating with the backend REST API.
+class ApiService {
+  ApiService({http.Client? client, this.baseUrl = 'https://example.com/api'})
+      : _client = client ?? http.Client();
+
+  final http.Client _client;
+  final String baseUrl;
+
+  /// Transfers [amount] of money to the given [provider].
+  ///
+  /// Throws an [ApiException] when the request fails or times out.
+  Future<Map<String, dynamic>> transferMoney({
+    required String provider,
+    required double amount,
+  }) async {
+    final uri = Uri.parse('$baseUrl/transfer');
+
+    try {
+      final response = await _client
+          .post(
+            uri,
+            headers: {'Content-Type': 'application/json'},
+            body: jsonEncode({'provider': provider, 'amount': amount}),
+          )
+          .timeout(const Duration(seconds: 10));
+
+      if (response.statusCode >= 200 && response.statusCode < 300) {
+        return response.body.isNotEmpty
+            ? jsonDecode(response.body) as Map<String, dynamic>
+            : <String, dynamic>{};
+      } else {
+        throw ApiException(
+          'Failed to transfer money',
+          response.statusCode,
+          response.body,
+        );
+      }
+    } on TimeoutException {
+      throw ApiException('Request timed out');
+    } on http.ClientException catch (e) {
+      throw ApiException('Network error: $e');
+    }
+  }
+
+  /// Releases any resources held by the underlying HTTP client.
+  void dispose() => _client.close();
+}
+
+/// A simple exception that wraps API related errors.
+class ApiException implements Exception {
+  ApiException(this.message, [this.statusCode, this.body]);
+
+  final String message;
+  final int? statusCode;
+  final String? body;
+
+  @override
+  String toString() {
+    final code = statusCode != null ? ' (status: $statusCode)' : '';
+    return 'ApiException: $message$code';
+  }
+}
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_svg: ^2.0.10+1
+  http: ^1.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add `http` dependency
- create `ApiService` with transferMoney and error handling
- wire `ApiService` into `TransferMoneyScreen`

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1395d564c8332adfb81ecf181ee23