### PR TITLE
fix: correct svg asset paths

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -90,7 +90,7 @@ class WalletScreen extends StatelessWidget {
               // Mapache (SVG desde assets)
               Center(
                 child: SvgPicture.asset(
-                  'assets/Vector.svg',
+                  'assets/svg/Vector.svg',
                   width: 300,
                   fit: BoxFit.contain,
                 ),
@@ -242,7 +242,7 @@ class _EarningsProgress extends StatelessWidget {
               Align(
                 alignment: Alignment(progress * 2 - 1, 0),
                 child: SvgPicture.asset(
-                  'assets/Group.svg',
+                  'assets/svg/Group.svg',
                   width: 28,
                   fit: BoxFit.contain,
                 ),

--- a/lib/screens/success.dart
+++ b/lib/screens/success.dart
@@ -25,7 +25,7 @@ class SuccessScreen extends StatelessWidget {
             // 👇🏼 REMPLAZO DEL CustomPaint POR SVG
             Center(
               child: SvgPicture.asset(
-                'assets/Vector.svg', // tu mapache
+                'assets/svg/Vector.svg', // tu mapache
                 width: 200,
                 fit: BoxFit.contain,
               ),


### PR DESCRIPTION
## Summary
- point Vector.svg and Group.svg assets to `assets/svg/`

## Testing
- `flutter test` *(fails: command not found)*
- `flutter run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c139550dd48332be8b655cca88de66